### PR TITLE
Fix broken GSoC blog post link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ First of all, please read the above-referenced resources and the [GSoC FAQ](http
 4. Come up with project that you're interested in and discuss it in [Features category](https://discourse.joplinapp.org/c/features)
 5. Write a first draft and get someone to review it
 6. Remember: you must link to work such as commits in your proposal. A private place will be created within the forum for that purposes.
-7. Read [How to write a kickass proposal for GSoC](http://teom.org/blog/kde/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
+7. Read [How to write a kickass proposal for GSoC](https://web.archive.org/web/20190731094855/http://teom.org/blog/kde/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/)
 8. Submit proposal using [Google's web interface](https://summerofcode.withgoogle.com/) ahead of the deadline
 9. Submit proof of enrolment well ahead of the deadline
 


### PR DESCRIPTION
# Summary

At present, I'm unable to access `teom.org`. I'm opening this pull request as a draft because I'm unsure whether the server used for the website is temporarily or permanently down.

This pull request updates the link to point to an archived copy of the page. An alternative link might be https://teom.wordpress.com/2012/03/01/how-to-write-a-kick-ass-proposal-for-google-summer-of-code/, though that blog post seems to be four years older than the one stored in the Wayback machine.