### PR TITLE
Pull request guidelines: Add link to AI policy

### DIFF
--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -22,10 +22,12 @@ Due to our limited resources and in order to give everyone a chance to submit a 
 
 5. **All pull request must have test units**. In some cases it might be almost impossible to add such tests (for example integration tests), but for anything else we insist on having them, and we may close the pull request if we see they could have been added but weren't. If you don't know how to add test units, please ask on the forum or Discord. If really it's not possible to add tests, we'll let you know at this point. Also please check again the [Automated Tests](https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md#automated-tests) documentation for more information.
 
-6. **No Work In Progress**. ONLY completed and working pull requests, and with test units, will be accepted. A WIP would fall under rule 3 and be closed immediately.
+6. AI-assisted contributions must follow the [AI policy](https://github.com/personalizedrefrigerator/gsoc/blob/main/ai_policy.md).
 
-7. Please **do not `@mention` contributors and mentors and do not ask for pull request reviews**. Sometimes it takes time before we can review your pull request or answer your questions but we'll get to it sooner or later. `@mentioning` someone just adds to the pile of notifications we get and it won't make us look at your issue faster.
+7. **No Work In Progress**. ONLY completed and working pull requests, and with test units, will be accepted. A WIP would fall under rule 3 and be closed immediately.
 
-8. **Do not force push**. If you make changes to your pull request, please simply add a new commit as that makes it easy for us to review your new changes. If you force push, we'll have to review everything from the beginning.
+8. Please **do not `@mention` contributors and mentors and do not ask for pull request reviews**. Sometimes it takes time before we can review your pull request or answer your questions but we'll get to it sooner or later. `@mentioning` someone just adds to the pile of notifications we get and it won't make us look at your issue faster.
+
+9. **Do not force push**. If you make changes to your pull request, please simply add a new commit as that makes it easy for us to review your new changes. If you force push, we'll have to review everything from the beginning.
 
 These rules we hope are fair to everyone, to contributors and maintainers, however if something is unclear or you have any question about them, please let us know!


### PR DESCRIPTION
# Summary

This pull request adds a link to the AI policy in the pull request guidelines. This should make the AI policy easier to discover.