### PR TITLE
Fix broken link for pull request guidelines in GSoC README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ The focus this year is on:
 
 We suggest you read carefully these important documents and bookmark the links as you will need to refer to them throughout GSoC:
 
-- [How to submit a pull request for GSoC](https://github.com/joplin/gsoc/blob/main/pull_request_guidelines.md)
+- [How to submit a pull request for GSoC](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md)
 - [How to build the apps](https://github.com/laurent22/joplin/blob/dev/readme/dev/BUILD.md)
 - [How to contribute](https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md)
 


### PR DESCRIPTION
## Problem

The link "How to submit a pull request for GSoC" in the README pointed to the `main` branch.  
However, the repository currently uses `master` as the default branch, which resulted in an error page when opening the link.

## Solution

Updated the link to reference the `master` branch instead of `main`.  
This ensures the pull request guidelines page opens correctly.

## Test Plan

1. Open the README file.
2. Click the "How to submit a pull request for GSoC" link.
3. Verify that the pull_request_guidelines.md page loads correctly.