### PR TITLE
Update AI policy for PRs

### DIFF
--- a/ai_policy.md
+++ b/ai_policy.md
@@ -4,7 +4,7 @@ We accept the use of AI tools (e.g. LLMs) to assist with contributions. However,
 
 ### Disclosure requirement
 
-All contributions must include a section at the top titled:
+All contributions, whether AI-assisted or not, **must** include a section at the top titled:
 
 "**AI Assistance Disclosure**"
 
@@ -15,6 +15,8 @@ This section must clearly:
 * Confirm that you have:
   * Reviewed the output carefully
   * Fully understand the generated code or text
+ 
+If AI-assistance was *not* used in your contribution, then please state this in the disclosure instead.
 
 ### Proposals
 

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -22,11 +22,11 @@ Due to our limited resources and in order to give everyone a chance to submit a 
 
 5. AI-assisted contributions must follow the [AI policy](https://github.com/joplin/gsoc/blob/master/ai_policy.md). This includes the "AI assistance disclaimer" which **must** be present on all pull requests, whether AI-assisted or not. If AI-assistance was not used then please state this in the disclaimer.
 
-7. **No Work In Progress**. ONLY completed and working pull requests, and with test units, will be accepted.
+6. **No Work In Progress**. ONLY completed and working pull requests, and with test units, will be accepted.
 
-8. Please **do not `@mention` contributors and mentors and do not ask for pull request reviews**. Sometimes it takes time before we can review your pull request or answer your questions but we'll get to it sooner or later. `@mentioning` someone just adds to the pile of notifications we get and it won't make us look at your issue faster.
+7. Please **do not `@mention` contributors and mentors and do not ask for pull request reviews**. Sometimes it takes time before we can review your pull request or answer your questions but we'll get to it sooner or later. `@mentioning` someone just adds to the pile of notifications we get and it won't make us look at your issue faster.
 
-9. **Do not force push**. If you make changes to your pull request, please simply add a new commit as that makes it easy for us to review your new changes. If you force push, we'll have to review everything from the beginning.
+8. **Do not force push**. If you make changes to your pull request, please simply add a new commit as that makes it easy for us to review your new changes. If you force push, we'll have to review everything from the beginning.
 
 ## PR Description Guidelines
 

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -20,7 +20,7 @@ Due to our limited resources and in order to give everyone a chance to submit a 
 
 4. **All pull request must have test units**. In some cases it might be almost impossible to add such tests (for example integration tests), but for anything else we insist on having them. Please check the [Automated Tests](https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md#automated-tests) documentation for more information.
 
-5. AI-assisted contributions must follow the [AI policy](https://github.com/joplin/gsoc/blob/master/ai_policy.md). This includes the "AI assistance disclaimer" which **must** be present on all pull requests, whether AI-assisted or not. If AI-assistance was not used then please state this in the disclaimer.
+5. AI-assisted contributions must follow the [AI policy](https://github.com/joplin/gsoc/blob/master/ai_policy.md). This includes the "AI assistance disclosure" which **must** be present on all pull requests, whether AI-assisted or not. If AI-assistance was not used then please state this in the disclosure.
 
 6. **No Work In Progress**. ONLY completed and working pull requests, and with test units, will be accepted.
 

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -20,13 +20,13 @@ Due to our limited resources and in order to give everyone a chance to submit a 
 
 4. **All pull request must have test units**. In some cases it might be almost impossible to add such tests (for example integration tests), but for anything else we insist on having them. Please check the [Automated Tests](https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md#automated-tests) documentation for more information.
 
-5. AI-assisted contributions must follow the [AI policy](https://github.com/personalizedrefrigerator/gsoc/blob/main/ai_policy.md).
+5. AI-assisted contributions must follow the [AI policy](https://github.com/joplin/gsoc/blob/master/ai_policy.md). This includes the "AI assistance disclaimer" which **must** be present on all pull requests, whether AI-assisted or not. If AI-assistance was not used then please state this in the disclaimer.
 
-6. **No Work In Progress**. ONLY completed and working pull requests, and with test units, will be accepted.
+7. **No Work In Progress**. ONLY completed and working pull requests, and with test units, will be accepted.
 
-7. Please **do not `@mention` contributors and mentors and do not ask for pull request reviews**. Sometimes it takes time before we can review your pull request or answer your questions but we'll get to it sooner or later. `@mentioning` someone just adds to the pile of notifications we get and it won't make us look at your issue faster.
+8. Please **do not `@mention` contributors and mentors and do not ask for pull request reviews**. Sometimes it takes time before we can review your pull request or answer your questions but we'll get to it sooner or later. `@mentioning` someone just adds to the pile of notifications we get and it won't make us look at your issue faster.
 
-8. **Do not force push**. If you make changes to your pull request, please simply add a new commit as that makes it easy for us to review your new changes. If you force push, we'll have to review everything from the beginning.
+9. **Do not force push**. If you make changes to your pull request, please simply add a new commit as that makes it easy for us to review your new changes. If you force push, we'll have to review everything from the beginning.
 
 ## PR Description Guidelines
 


### PR DESCRIPTION
Adds requirement that disclaimer must be used on all PRs whether assisted or not.

Also fixes a link that was directed to a gsoc repo fork and not at this repo.