### PR TITLE
Remove idea 8. password strength indicator

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -127,21 +127,7 @@ In general, notes in Joplin are immediately accessible. However the user may wan
 
 **Expected size of project**: 175 hours
 
-### 8. Password strength indicator
-
-Implement a password strength indicator to help users create stronger master passwords. The indicator can visually guide users on how secure their password is when setting or changing it.
-
-**Expected Outcome**: A UI element that displays password strength as the user types. Feedback to the user on how to improve their password strength (e.g. adding numbers, special characters). Integration with an algorithm like zxcvbn to evaluate password strength.
-
-**Difficulty Level**: Easy
-
-**Skills Required**: TypeScript, React (for UI)
-
-**Potential Mentors**: PackElend, Laurent
-
-**Expected size of project**: 90 hours
-
-### 9. LAN Sync
+### 8. LAN Sync
 
 Implement device-to-device synchronisation (LAN Sync). The application can already sync using various servers, but it would be good to also allow sync fully offline by having the devices connect to each other directly.
 
@@ -155,7 +141,7 @@ Implement device-to-device synchronisation (LAN Sync). The application can alrea
 
 **Expected size of project**: 175 hours
 
-### 10. Automatic conflict resolution
+### 9. Automatic conflict resolution
 
 Implement a mechanism to automatically resolve note conflicts where possible, and provide semi-autonomous or assisted conflict resolution when automatic resolution is not feasible. Note conflicts occur when a note is edited while the local version is not synchronized with the latest version stored on the server. At present, resolving these conflicts requires manual intervention, which can be time-consuming and particularly challenging for longer notes, especially on mobile devices. The project may optionally explore the use of AI to assist with the conflict resolution process, though this is not a required component.
 


### PR DESCRIPTION
As discussed it seems this project may not be of sufficient length to fill the required hours of GSoC. Original idea was made before advancement in AI capabilities so may now be almost trivial.

If no open issue exists then we could create one with some defined requirements.

Some contributors have already submitted draft proposals - we should make it clear to them and all potential contributors on the forum that we have removed this idea from the project list.